### PR TITLE
modified to trim padding out from aligned faces when `args.has_aligned` is True

### DIFF
--- a/inference_face.py
+++ b/inference_face.py
@@ -173,6 +173,8 @@ def main() -> None:
                 # save restored face
                 if args.has_aligned:
                     save_face_name = f'{basename}.{img_save_ext}'
+                    # remove padding
+                    restored_face = restored_face[:lq_resized.height, :lq_resized.width, :]
                 else:
                     save_face_name = f'{basename}_{idx:02d}.{img_save_ext}'
                 save_restore_path = os.path.join(parent_path, 'restored_faces', save_face_name)


### PR DESCRIPTION
When ```args.has_aligned == True```, the padded image is used directly as ```face_helper.cropped_faces```. So we should remove the padding from the ```restored_face``` before save it.
This commit solves the problem.